### PR TITLE
Borsh Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/tightenco/solana-php-sdk.svg?style=flat-square)](https://packagist.org/packages/tightenco/solana-php-sdk)
 [![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/tighten/solana-php-sdk/run-tests?label=tests)](https://github.com/tighten/solana-php-sdk/actions?query=workflow%3Arun-tests+branch%3Amain)
 
+> :warning: This is an alpha release; functionality may change.
 
 Simple PHP SDK for Solana.
 
@@ -54,6 +55,40 @@ $accountInfoResponse = $client->call('getAccountInfo', ['4fYNw3dojWmQ4dXtSGE9epj
 $accountInfoBody = $accountInfoResponse->json();
 $accountInfoStatusCode = $accountInfoResponse->getStatusCode();
 ``````
+
+### Transactions
+
+Here is working example of sending a transfer instruction to the Solana blockchain:
+
+```php
+$client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
+$connection = new Connection($client);
+$fromPublicKey = KeyPair::fromSecretKey([...]);
+$toPublicKey = new PublicKey('J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99');
+$instruction = SystemProgram::transfer(
+    $fromPublicKey->getPublicKey(),
+    $toPublicKey,
+    6
+);
+
+$transaction = new Transaction(null, null, $fromPublicKey->getPublicKey());
+$transaction->add($instruction);
+
+$txHash = $connection->sendTransaction($transaction, $fromPublicKey);
+```
+
+Note: This project is in alpha, the code to generate instructions is still being worked on `$instruction = SystemProgram::abc()`
+
+## Roadmap
+
+1. Borsh serialize and deserialize.
+2. Improved documentation.
+3. Build out more of the Connection, SystemProgram, TokenProgram, MetaplexProgram classes.
+4. Improve abstractions around working with binary data.
+5. Optimizations:
+   1. Leverage PHP more.
+   2. Better cache `$recentBlockhash` when sending transactions.
+6. Suggestions? Open an issue or PR :D
 
 ## Testing
 

--- a/src/Borsh/BinaryReader.php
+++ b/src/Borsh/BinaryReader.php
@@ -22,10 +22,7 @@ class BinaryReader
      */
     public function readU8(): int
     {
-        $valueArray = $this->buffer->slice($this->offset, 1);
-        $value = $valueArray->toInt();
-        $this->offset += 1;
-        return $value;
+        return $this->readUnsignedInt(1, Buffer::TYPE_BYTE);
     }
 
     /**
@@ -33,10 +30,7 @@ class BinaryReader
      */
     public function readU16(): int
     {
-        $valueArray = $this->buffer->slice($this->offset, 2);
-        $value = $valueArray->toInt();
-        $this->offset += 2;
-        return $value;
+        return $this->readUnsignedInt(2, Buffer::TYPE_SHORT);
     }
 
     /**
@@ -44,10 +38,7 @@ class BinaryReader
      */
     public function readU32(): int
     {
-        $valueArray = $this->buffer->slice($this->offset, 4);
-        $value = $valueArray->toInt();
-        $this->offset += 4;
-        return $value;
+        return $this->readUnsignedInt(4, Buffer::TYPE_INT);
     }
 
     /**
@@ -55,42 +46,80 @@ class BinaryReader
      */
     public function readU64(): int
     {
-        $valueArray = $this->buffer->slice($this->offset, 8);
-        $value = $valueArray->toInt();
+        return $this->readUnsignedInt(8, Buffer::TYPE_LONG);
+    }
+
+    /**
+     * @return int
+     */
+    public function readI8(): int
+    {
+        return $this->readSignedInt(1, Buffer::TYPE_BYTE);
+    }
+
+    /**
+     * @return int
+     */
+    public function readI16(): int
+    {
+        return $this->readSignedInt(2, Buffer::TYPE_SHORT);
+    }
+
+    /**
+     * @return int
+     */
+    public function readI32(): int
+    {
+        return $this->readSignedInt(4, Buffer::TYPE_INT);
+    }
+
+    /**
+     * @return int
+     */
+    public function readI64(): int
+    {
+        return $this->readSignedInt(8, Buffer::TYPE_LONG);
+    }
+
+    /**
+     * @param $length
+     * @return int
+     */
+    protected function readUnsignedInt($length, $datatype): int
+    {
+        $value = $this->buffer->slice($this->offset, $length, $datatype, false)->value();
+        $this->offset += $length;
+        return $value;
+    }
+
+    /**
+     * @param $length
+     * @return int
+     */
+    protected function readSignedInt($length, $datatype): int
+    {
+        $value = $this->buffer->slice($this->offset, $length, $datatype, true)->value();
+        $this->offset += $length;
+        return $value;
+    }
+
+    /**
+     * @return float
+     */
+    public function readF32(): float
+    {
+        $value = $this->buffer->slice($this->offset, 4, Buffer::TYPE_FLOAT, true)->value();
+        $this->offset += 4;
+        return $value;
+    }
+
+    /**
+     * @return float
+     */
+    public function readF64(): float
+    {
+        $value = $this->buffer->slice($this->offset, 8, Buffer::TYPE_FLOAT, true)->value();
         $this->offset += 8;
-        return $value;
-    }
-
-    /**
-     * @return int
-     */
-    public function readU128(): int
-    {
-        $valueArray = $this->buffer->slice($this->offset, 16);
-        $value = $valueArray->toInt();
-        $this->offset += 16;
-        return $value;
-    }
-
-    /**
-     * @return int
-     */
-    public function readU256(): int
-    {
-        $valueArray = $this->buffer->slice($this->offset, 32);
-        $value = $valueArray->toInt();
-        $this->offset += 32;
-        return $value;
-    }
-
-    /**
-     * @return int
-     */
-    public function readU512(): int
-    {
-        $valueArray = $this->buffer->slice($this->offset, 64);
-        $value = $valueArray->toInt();
-        $this->offset += 64;
         return $value;
     }
 
@@ -101,8 +130,7 @@ class BinaryReader
     public function readString(): string
     {
         $length = $this->readU32();
-        $buffer = $this->readBuffer($length);
-        return pack('C*', ...$buffer->toArray());
+        return $this->readBuffer($length);
     }
 
     /**
@@ -116,7 +144,6 @@ class BinaryReader
 
     /**
      * @return array
-     * @throws TodoException
      */
     public function readArray(Closure $readEachItem): array
     {

--- a/src/Borsh/BinaryReader.php
+++ b/src/Borsh/BinaryReader.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+use Tighten\SolanaPhpSdk\Exceptions\TodoException;
+use Tighten\SolanaPhpSdk\Util\Buffer;
+use Closure;
+
+class BinaryReader
+{
+    protected Buffer $buffer;
+    protected int $offset;
+
+    public function __construct(Buffer $buffer)
+    {
+        $this->buffer = $buffer;
+        $this->offset = 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU8(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 1);
+        $value = $valueArray->toInt();
+        $this->offset += 1;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU16(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 2);
+        $value = $valueArray->toInt();
+        $this->offset += 2;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU32(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 4);
+        $value = $valueArray->toInt();
+        $this->offset += 4;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU64(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 8);
+        $value = $valueArray->toInt();
+        $this->offset += 8;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU128(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 16);
+        $value = $valueArray->toInt();
+        $this->offset += 16;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU256(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 32);
+        $value = $valueArray->toInt();
+        $this->offset += 32;
+        return $value;
+    }
+
+    /**
+     * @return int
+     */
+    public function readU512(): int
+    {
+        $valueArray = $this->buffer->slice($this->offset, 64);
+        $value = $valueArray->toInt();
+        $this->offset += 64;
+        return $value;
+    }
+
+    /**
+     * @return string
+     * @throws BorshException
+     */
+    public function readString(): string
+    {
+        $length = $this->readU32();
+        $buffer = $this->readBuffer($length);
+        return pack('C*', ...$buffer->toArray());
+    }
+
+    /**
+     * @param int $length
+     * @return array
+     */
+    public function readFixedArray(int $length): array
+    {
+        return $this->readBuffer($length)->toArray();
+    }
+
+    /**
+     * @return array
+     * @throws TodoException
+     */
+    public function readArray(Closure $readEachItem): array
+    {
+        $length = $this->readU32();
+        $array = [];
+        for ($i = 0; $i < $length; $i++) {
+            array_push($array, $readEachItem());
+        }
+        return $array;
+    }
+
+    /**
+     * @param $length
+     * @return Buffer
+     * @throws BorshException
+     */
+    protected function readBuffer($length): Buffer
+    {
+        if ($this->offset + $length > sizeof($this->buffer)) {
+            throw new BorshException("Expected buffer length {$length} isn't within bounds");
+        }
+
+        $buffer = $this->buffer->slice($this->offset, $length);
+        $this->offset += $length;
+        return $buffer;
+    }
+
+}

--- a/src/Borsh/BinaryWriter.php
+++ b/src/Borsh/BinaryWriter.php
@@ -23,9 +23,7 @@ class BinaryWriter
      */
     public function writeU8(int $value)
     {
-        $this->buffer->push($value, 1);
-        $this->length += 1;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_BYTE, false));
     }
 
     /**
@@ -34,9 +32,7 @@ class BinaryWriter
      */
     public function writeU16(int $value)
     {
-        $this->buffer->push($value, 2);
-        $this->length += 2;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_SHORT, false));
     }
 
     /**
@@ -45,9 +41,7 @@ class BinaryWriter
      */
     public function writeU32(int $value)
     {
-        $this->buffer->push($value, 4);
-        $this->length += 4;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_INT, false));
     }
 
     /**
@@ -56,42 +50,61 @@ class BinaryWriter
      */
     public function writeU64(int $value)
     {
-        $this->buffer->push($value, 8);
-        $this->length += 8;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_LONG, false));
     }
 
     /**
      * @param int $value
      * @return $this
      */
-    public function writeU128(int $value)
+    public function writeI8(int $value)
     {
-        $this->buffer->push($value, 16);
-        $this->length += 16;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_BYTE, true));
     }
 
     /**
      * @param int $value
      * @return $this
      */
-    public function writeU256(int $value)
+    public function writeI16(int $value)
     {
-        $this->buffer->push($value, 32);
-        $this->length += 32;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_SHORT, true));
     }
 
     /**
      * @param int $value
      * @return $this
      */
-    public function writeU512(int $value)
+    public function writeI32(int $value)
     {
-        $this->buffer->push($value, 64);
-        $this->length += 64;
-        return $this;
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_INT, true));
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeI64(int $value)
+    {
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_LONG, true));
+    }
+
+    /**
+     * @param float $value
+     * @return $this
+     */
+    public function writeF32(float $value)
+    {
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_FLOAT, true)->fixed(4));
+    }
+
+    /**
+     * @param float $value
+     * @return $this
+     */
+    public function writeF64(float $value)
+    {
+        return $this->writeBuffer(Buffer::from($value, Buffer::TYPE_FLOAT, true)->fixed(8));
     }
 
     /**

--- a/src/Borsh/BinaryWriter.php
+++ b/src/Borsh/BinaryWriter.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+use Tighten\SolanaPhpSdk\Exceptions\TodoException;
+use Tighten\SolanaPhpSdk\Util\Buffer;
+use Closure;
+
+class BinaryWriter
+{
+    protected Buffer $buffer;
+    protected int $length;
+
+    public function __construct()
+    {
+        $this->buffer = Buffer::from();
+        $this->length = 0;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU8(int $value)
+    {
+        $this->buffer->push($value, 1);
+        $this->length += 1;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU16(int $value)
+    {
+        $this->buffer->push($value, 2);
+        $this->length += 2;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU32(int $value)
+    {
+        $this->buffer->push($value, 4);
+        $this->length += 4;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU64(int $value)
+    {
+        $this->buffer->push($value, 8);
+        $this->length += 8;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU128(int $value)
+    {
+        $this->buffer->push($value, 16);
+        $this->length += 16;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU256(int $value)
+    {
+        $this->buffer->push($value, 32);
+        $this->length += 32;
+        return $this;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function writeU512(int $value)
+    {
+        $this->buffer->push($value, 64);
+        $this->length += 64;
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function writeString(string $value)
+    {
+        $valueBuffer = Buffer::from($value);
+        $this->writeU32(sizeof($valueBuffer));
+        $this->writeBuffer($valueBuffer);
+        return $this;
+    }
+
+    /**
+     * @param array $array
+     * @return $this
+     */
+    public function writeFixedArray(array $array)
+    {
+        $this->writeBuffer(Buffer::from($array));
+        return $this;
+    }
+
+    /**
+     * @param array $array
+     * @return $this
+     */
+    public function writeArray(array $array, Closure $writeFn)
+    {
+        $this->writeU32(sizeof($array));
+        foreach ($array as $item) {
+            $writeFn($item);
+        }
+        return $this;
+    }
+
+    /**
+     * @param Buffer $buffer
+     * @return $this
+     */
+    protected function writeBuffer(Buffer $buffer)
+    {
+        $this->buffer->push($buffer);
+        $this->length += sizeof($buffer);
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->buffer->slice(0, $this->length)->toArray();
+    }
+}

--- a/src/Borsh/Borsh.php
+++ b/src/Borsh/Borsh.php
@@ -53,14 +53,14 @@ class Borsh
 
     /**
      * @param array $schema
-     * @param string $fieldName
+     * @param $fieldName
      * @param $value
      * @param $fieldType
      * @param BinaryWriter $writer
      */
     protected static function serializeField(
         array $schema,
-        string $fieldName,
+        $fieldName,
         $value,
         $fieldType,
         BinaryWriter $writer
@@ -152,13 +152,13 @@ class Borsh
 
     /**
      * @param array $schema
-     * @param string $fieldName
+     * @param $fieldName
      * @param $fieldType
      * @param BinaryReader $reader
      */
     protected static function deserializeField(
         array $schema,
-        string $fieldName,
+        $fieldName,
         $fieldType,
         BinaryReader $reader
     ) {

--- a/src/Borsh/Borsh.php
+++ b/src/Borsh/Borsh.php
@@ -135,7 +135,11 @@ class Borsh
         }
 
         if ($objectSchema['kind'] === 'struct') {
-            $result = new $class;
+            if (! method_exists($class, 'borshConstructor')) {
+                throw new BorshException("Class {$class} does not implement borshConstructor. Please use the BorshDeserialize trait.");
+            }
+
+            $result = $class::borshConstructor();
             foreach ($objectSchema['fields'] as list($fieldName, $fieldType)) {
                 $result->{$fieldName} = static::deserializeField($schema, $fieldName, $fieldType, $reader);
             }

--- a/src/Borsh/Borsh.php
+++ b/src/Borsh/Borsh.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+use Tighten\SolanaPhpSdk\Exceptions\TodoException;
+use Tighten\SolanaPhpSdk\Util\Buffer;
+
+class Borsh
+{
+    /**
+     * @param array $schema
+     * @param $object
+     * @return array
+     */
+    public static function serialize(
+        array $schema,
+        $object
+    ) : array
+    {
+        $writer = new BinaryWriter();
+        static::serializeObject($schema, $object, $writer);
+        return $writer->toArray();
+    }
+
+    /**
+     * @param array $schema
+     * @param $object
+     * @param BinaryWriter $writer
+     */
+    protected static function serializeObject(
+        array $schema,
+        $object,
+        BinaryWriter $writer
+    ) {
+        $objectSchema = $schema[get_class($object)] ?? null;
+        if (! $objectSchema) {
+            $class = get_class($object);
+            throw new BorshException("Class {$class} is missing in schema");
+        }
+
+        if ($objectSchema['kind'] === 'struct') {
+            foreach ($objectSchema['fields'] as list($fieldName, $fieldType)) {
+                static::serializeField($schema, $fieldName, $object->{$fieldName}, $fieldType, $writer);
+            }
+        } elseif ($objectSchema['kind'] === 'enum') {
+            throw new TodoException("TODO: Enums don't exist in PHP yet???");
+        } else {
+            $kind = $objectSchema['kind'];
+            $class = get_class($object);
+            throw new BorshException("Unexpected schema kind: {$kind} for {$class}");
+        }
+    }
+
+    /**
+     * @param array $schema
+     * @param string $fieldName
+     * @param $value
+     * @param $fieldType
+     * @param BinaryWriter $writer
+     */
+    protected static function serializeField(
+        array $schema,
+        string $fieldName,
+        $value,
+        $fieldType,
+        BinaryWriter $writer
+    ) {
+        if (is_string($fieldType)) {
+            $writer->{'write' . ucfirst($fieldType)}($value);
+        } elseif (is_array($fieldType) && isset($fieldType[0])) { // sequential array
+            if (is_int($fieldType[0])) {
+                if (sizeof($value) !== $fieldType[0]) {
+                    $sizeOf = sizeof($value);
+                    throw new BorshException("Expecting byte array of length {$fieldType[0]}, but got ${$sizeOf} bytes");
+                }
+                $writer->writeFixedArray($value);
+            } elseif (sizeof($fieldType) === 2 && is_int($fieldType[1])) {
+                if (sizeof($value) !== $fieldType[1]) {
+                    $sizeOf = sizeof($value);
+                    throw new BorshException("Expecting byte array of length {$fieldType[1]}, but got ${$sizeOf} bytes");
+                }
+
+                for ($i = 0; $i < $fieldType[1]; $i++) {
+                    static::serializeField($schema, null, $value[$i], $fieldType[0], $writer);
+                }
+            } else {
+                $writer->writeArray($value, fn ($item) => static::serializeField($schema, $fieldName, $item, $fieldType[0], $writer));
+            }
+        } elseif (isset($fieldType['kind'])) { // associative array
+            switch ($fieldType['kind']) {
+                case 'option':
+                    if ($value) {
+                        $writer->writeU8(1);
+                        static::serializeField($schema, $fieldName, $value, $fieldType['type'], $writer);
+                    } else {
+                        $writer->writeU8(0);
+                    }
+                    break;
+                default:
+                    throw new BorshException("FieldType {$fieldType['kind']} unrecognized");
+            }
+        } else {
+            static::serializeObject($schema, $value, $writer);
+        }
+    }
+
+    /**
+     * @param array $schema
+     * @param string $class
+     * @param array $buffer
+     */
+    public static function deserialize(
+        array $schema,
+        string $class,
+        array $buffer
+    )
+    {
+        $reader = new BinaryReader(Buffer::from($buffer));
+        return static::deserializeObject($schema, $class, $reader);
+    }
+
+    /**
+     * @param array $schema
+     * @param string $class
+     * @param BinaryReader $reader
+     */
+    protected static function deserializeObject(
+        array $schema,
+        string $class,
+        BinaryReader $reader
+    ) {
+        $objectSchema = $schema[$class] ?? null;
+        if (! $objectSchema) {
+            throw new BorshException("Class {$class} is missing in schema");
+        }
+
+        if ($objectSchema['kind'] === 'struct') {
+            $result = new $class;
+            foreach ($objectSchema['fields'] as list($fieldName, $fieldType)) {
+                $result->{$fieldName} = static::deserializeField($schema, $fieldName, $fieldType, $reader);
+            }
+            return $result;
+        }
+
+        if ($objectSchema['kind'] === 'enum') {
+            throw new TodoException("TODO: Enums don't exist in PHP yet???");
+        }
+
+        $kind = $objectSchema['kind'];
+        throw new BorshException("Unexpected schema kind: {$kind} for {$class}");
+    }
+
+    /**
+     * @param array $schema
+     * @param string $fieldName
+     * @param $fieldType
+     * @param BinaryReader $reader
+     */
+    protected static function deserializeField(
+        array $schema,
+        string $fieldName,
+        $fieldType,
+        BinaryReader $reader
+    ) {
+        if (is_string($fieldType)) {
+            return $reader->{'read' . ucfirst($fieldType)}();
+        }
+
+        if (is_array($fieldType) && isset($fieldType[0])) { // sequential array
+            if (is_int($fieldType[0])) {
+                return $reader->readFixedArray($fieldType[0]);
+            } elseif (sizeof($fieldType) === 2 && is_int($fieldType[1])) {
+                $array = [];
+                for ($i = 0; $i < $fieldType[1]; $i++) {
+                    array_push($array, static::deserializeField($schema, null, $fieldType[0], $reader));
+                }
+                return $array;
+            } else {
+                return $reader->readArray(fn () => static::deserializeField($schema, $fieldName, $fieldType[0], $reader));
+            }
+        }
+
+        if (isset($fieldType['kind']) && $fieldType['kind'] === 'option') { // associative array
+            $option = $reader->readU8();
+            if ($option) {
+                return static::deserializeField($schema, $fieldName, $fieldType['type'], $reader);
+            }
+
+            return null;
+        }
+
+        return static::deserializeObject($schema, $fieldType, $reader);
+    }
+}

--- a/src/Borsh/BorshDeserializable.php
+++ b/src/Borsh/BorshDeserializable.php
@@ -4,6 +4,22 @@ namespace Tighten\SolanaPhpSdk\Borsh;
 
 trait BorshDeserializable
 {
+    /**
+     * Create a new instance of this object.
+     *
+     * Note: must override when the default constructor required parameters!
+     *
+     * @return $this
+     */
+    public static function borshConstructor()
+    {
+        return new static();
+    }
+
+    /**
+     * @param $name
+     * @param $value
+     */
     public function __set($name, $value)
     {
         $this->{$name} = $value;

--- a/src/Borsh/BorshDeserializable.php
+++ b/src/Borsh/BorshDeserializable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+trait BorshDeserializable
+{
+    public function __set($name, $value)
+    {
+        $this->{$name} = $value;
+    }
+}

--- a/src/Borsh/BorshException.php
+++ b/src/Borsh/BorshException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+use Tighten\SolanaPhpSdk\Exceptions\BaseSolanaPhpSdkException;
+
+class BorshException extends BaseSolanaPhpSdkException
+{
+
+}

--- a/src/Borsh/BorshObject.php
+++ b/src/Borsh/BorshObject.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+trait BorshObject
+{
+    use BorshDeserializable;
+    use BorshSerializable;
+}

--- a/src/Borsh/BorshSerializable.php
+++ b/src/Borsh/BorshSerializable.php
@@ -4,6 +4,10 @@ namespace Tighten\SolanaPhpSdk\Borsh;
 
 trait BorshSerializable
 {
+    /**
+     * @param $name
+     * @return mixed
+     */
     public function __get($name)
     {
         return $this->{$name};

--- a/src/Borsh/BorshSerializable.php
+++ b/src/Borsh/BorshSerializable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Borsh;
+
+trait BorshSerializable
+{
+    public function __get($name)
+    {
+        return $this->{$name};
+    }
+}

--- a/src/Util/Buffer.php
+++ b/src/Util/Buffer.php
@@ -13,14 +13,22 @@ use SplFixedArray;
  */
 class Buffer implements Countable
 {
-    const FORMAT_SIGNED_CHAR = 'c';
-    const FORMAT_UNSIGNED_CHAR = 'C';
+    const TYPE_STRING = 'string';
+    const TYPE_BYTE = 'byte';
+    const TYPE_SHORT = 'short';
+    const TYPE_INT = 'int';
+    const TYPE_LONG = 'long';
+    const TYPE_FLOAT = 'float';
+
+    const FORMAT_CHAR_SIGNED = 'c';
+    const FORMAT_CHAR_UNSIGNED = 'C';
     const FORMAT_SHORT_16_SIGNED = 's';
     const FORMAT_SHORT_16_UNSIGNED = 'v';
     const FORMAT_LONG_32_SIGNED = 'l';
     const FORMAT_LONG_32_UNSIGNED = 'V';
     const FORMAT_LONG_LONG_64_SIGNED = 'q';
     const FORMAT_LONG_LONG_64_UNSIGNED = 'P';
+    const FORMAT_FLOAT = 'e';
 
     /**
      * @var array<int>
@@ -28,21 +36,42 @@ class Buffer implements Countable
     protected array $data;
 
     /**
+     * @var bool is this a signed or unsigned value?
+     */
+    protected ?bool $signed = null;
+
+    /**
+     * @var ?string $datatype
+     */
+    protected ?string $datatype = null;
+
+    /**
      * @param mixed $value
      */
-    public function __construct($value = null)
+    public function __construct($value = null, ?string $datatype = null, ?bool $signed = null)
     {
-        if (is_string($value)) {
+        $this->datatype = $datatype;
+        $this->signed = $signed;
+
+        $isString = is_string($value);
+        $isNumeric = is_numeric($value);
+
+        if ($isString || $isNumeric) {
+            $this->datatype = $datatype;
+            $this->signed = $signed;
+
             // unpack returns an array indexed at 1.
-            $this->data = array_values(unpack('C*', $value));
+            $this->data = $isString
+                ? array_values(unpack("C*", $value))
+                : array_values(unpack("C*", pack($this->computedFormat(), $value)));
         } elseif (is_array($value)) {
             $this->data = $value;
-        } elseif (is_numeric($value)) {
-            $this->data = [$value];
         } elseif ($value instanceof PublicKey) {
             $this->data = $value->toBytes();
         } elseif ($value instanceof Buffer) {
             $this->data = $value->toArray();
+            $this->datatype = $value->datatype;
+            $this->signed = $value->signed;
         } elseif ($value == null) {
             $this->data = [];
         } elseif (method_exists($value, 'toArray')) {
@@ -58,9 +87,9 @@ class Buffer implements Countable
      * @param $value
      * @return Buffer
      */
-    public static function from($value = null): Buffer
+    public static function from($value = null, ?string $format = null, ?bool $signed = null): Buffer
     {
-        return new static($value);
+        return new static($value, $format, $signed);
     }
 
     /**
@@ -108,9 +137,9 @@ class Buffer implements Countable
     /**
      * @return Buffer
      */
-    public function slice(int $offset, ?int $length = null): Buffer
+    public function slice(int $offset, ?int $length = null, ?string $format = null, ?bool $signed = null): Buffer
     {
-        return static::from(array_slice($this->data, $offset, $length));
+        return static::from(array_slice($this->data, $offset, $length), $format, $signed);
     }
 
     /**
@@ -190,35 +219,44 @@ class Buffer implements Countable
     }
 
     /**
-     * Convert the binary array to an int.
+     * Convert the binary array to its corresponding value derived from $datatype, $signed, and sizeof($data).
      *
      * Note: it is expected that the ->fixed($length) method has already been called.
      *
-     * @return int
+     * @return mixed
      */
-    public function toInt(?int $length = null): int
+    public function value(?int $length = null)
     {
         if ($length) {
             $this->fixed($length);
         }
 
-        $size = sizeof($this);
-
-        switch ($size) {
-            case 1: return $this->to(self::FORMAT_UNSIGNED_CHAR);
-            case 2: return $this->to(self::FORMAT_SHORT_16_UNSIGNED);
-            case 4: return $this->to(self::FORMAT_LONG_32_UNSIGNED);
-            case 8: return $this->to(self::FORMAT_LONG_LONG_64_SIGNED);
-            default: throw new TodoException("Large numbers that exceed PHP limits are not yet supported.");
+        if ($this->datatype === self::TYPE_STRING) {
+            return ord(pack("C*", ...$this->toArray()));
+        } else {
+            return unpack($this->computedFormat(), pack("C*", ...$this->toArray()))[1];
         }
     }
 
     /**
-     * @param $format
-     * @return false|int|string
+     * @return string
+     * @throws InputValidationException
      */
-    protected function to($format)
+    protected function computedFormat()
     {
-        return ord(pack("{$format}*", ...$this->toArray()));
+        if (! $this->datatype) {
+            throw new InputValidationException('Trying to calculate format of unspecified buffer. Please specify a datatype.');
+        }
+
+        switch ($this->datatype) {
+            case self::TYPE_STRING: return self::FORMAT_CHAR_UNSIGNED;
+            case self::TYPE_BYTE: return $this->signed ? self::FORMAT_CHAR_SIGNED : self::FORMAT_CHAR_UNSIGNED;
+            case self::TYPE_SHORT: return $this->signed ? self::FORMAT_SHORT_16_SIGNED : self::FORMAT_SHORT_16_UNSIGNED;
+            case self::TYPE_INT: return $this->signed ? self::FORMAT_LONG_32_SIGNED : self::FORMAT_LONG_32_UNSIGNED;
+            case self::TYPE_LONG: return $this->signed ? self::FORMAT_LONG_LONG_64_SIGNED : self::FORMAT_LONG_LONG_64_UNSIGNED;
+            case self::TYPE_FLOAT: return self::FORMAT_FLOAT;
+            default: throw new InputValidationException("Unsupported datatype.");
+        }
     }
+
 }

--- a/src/Util/Buffer.php
+++ b/src/Util/Buffer.php
@@ -121,13 +121,9 @@ class Buffer implements Countable
      * @param $source
      * @return $this
      */
-    public function push($source, ?int $fixedSize = null): Buffer
+    public function push($source): Buffer
     {
         $sourceAsBuffer = Buffer::from($source);
-
-        if ($fixedSize != null) {
-            $sourceAsBuffer->fixed($fixedSize);
-        }
 
         array_push($this->data, ...$sourceAsBuffer->toArray());
 

--- a/tests/Unit/BorshTest.php
+++ b/tests/Unit/BorshTest.php
@@ -86,4 +86,26 @@ class BorshTest extends TestCase
         $newValue = Borsh::deserialize($schema, Test::class, $buffer);
         $this->assertNull($newValue->x);
     }
+
+    /** @test */
+    public function it_serialize_deserialize_fixed_array()
+    {
+        $schema = [
+            Test::class => [
+                'kind' => 'struct',
+                'fields' => [
+                    ['x', ['string', 2]],
+                ],
+            ],
+        ];
+
+        $value = new Test();
+        $value->x = ['hello', 'world'];
+
+        $buffer = Borsh::serialize($schema, $value);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+
+        $this->assertEquals([5, 0, 0, 0, 104, 101, 108, 108, 111, 5, 0, 0, 0, 119, 111, 114, 108, 100], $buffer);
+        $this->assertEquals(['hello', 'world'], $newValue->x);
+    }
 }

--- a/tests/Unit/BorshTest.php
+++ b/tests/Unit/BorshTest.php
@@ -9,6 +9,9 @@ class Test {
     public $x;
     public $y;
     public $z;
+    public $a;
+    public $b;
+    public $c;
     public $q;
 
     public function __construct() {}
@@ -23,6 +26,9 @@ class BorshTest extends TestCase
         $value->x = 255;
         $value->y = 20;
         $value->z = '123';
+        $value->a = 12.987;
+        $value->b = -121;
+        $value->c = -20;
         $value->q = [1, 2, 3];
 
         $schema = [
@@ -32,6 +38,9 @@ class BorshTest extends TestCase
                     ['x', 'u8'],
                     ['y', 'u64'],
                     ['z', 'string'],
+                    ['a', 'f64'],
+                    ['b', 'i32'],
+                    ['c', 'i8'],
                     ['q', [3]],
                 ],
             ],
@@ -44,37 +53,9 @@ class BorshTest extends TestCase
         $this->assertEquals(255, $newValue->x);
         $this->assertEquals(20, $newValue->y);
         $this->assertEquals('123', $newValue->z);
-        $this->assertEquals([1, 2, 3], $newValue->q);
-    }
-
-    /** @test */
-    public function it_serialize_nested()
-    {
-        $child = new Test();
-        $child->q = [1, 2, 4];
-
-        $parent = new Test();
-        $parent->x = 255;
-        $parent->y = $child;
-
-        $schema = [
-            Test::class => [
-                'kind' => 'struct',
-                'fields' => [
-                    ['x', 'u8'],
-                    ['y', Test::class],
-                    ['q', [3]],
-                ],
-            ],
-        ];
-
-        $buffer = Borsh::serialize($schema, $parent);
-        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
-
-        $this->assertInstanceOf(Test::class, $newValue);
-        $this->assertEquals(255, $newValue->x);
-        $this->assertEquals(20, $newValue->y);
-        $this->assertEquals('123', $newValue->z);
+        $this->assertEquals(12.987, $newValue->a);
+        $this->assertEquals(-121, $newValue->b);
+        $this->assertEquals(-20, $newValue->c);
         $this->assertEquals([1, 2, 3], $newValue->q);
     }
 

--- a/tests/Unit/BorshTest.php
+++ b/tests/Unit/BorshTest.php
@@ -3,9 +3,12 @@
 namespace Tighten\SolanaPhpSdk\Tests\Unit;
 
 use Tighten\SolanaPhpSdk\Borsh\Borsh;
+use Tighten\SolanaPhpSdk\Borsh\BorshObject;
 use Tighten\SolanaPhpSdk\Tests\TestCase;
 
 class Test {
+    use BorshObject;
+
     public $x;
     public $y;
     public $z;
@@ -13,8 +16,12 @@ class Test {
     public $b;
     public $c;
     public $q;
+    private $m;
 
     public function __construct() {}
+
+    public function setM($m) {$this->m = $m;}
+    public function getM() {return $this->m;}
 }
 
 class BorshTest extends TestCase
@@ -107,5 +114,27 @@ class BorshTest extends TestCase
 
         $this->assertEquals([5, 0, 0, 0, 104, 101, 108, 108, 111, 5, 0, 0, 0, 119, 111, 114, 108, 100], $buffer);
         $this->assertEquals(['hello', 'world'], $newValue->x);
+    }
+
+    /** @test */
+    public function it_serialize_deserialize_invisible_properties()
+    {
+        $value = new Test();
+        $value->setM(255);
+
+        $schema = [
+            Test::class => [
+                'kind' => 'struct',
+                'fields' => [
+                    ['m', 'u8'],
+                ],
+            ],
+        ];
+
+        $buffer = Borsh::serialize($schema, $value);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+
+        $this->assertInstanceOf(Test::class, $newValue);
+        $this->assertEquals(255, $newValue->getM());
     }
 }

--- a/tests/Unit/BorshTest.php
+++ b/tests/Unit/BorshTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Tests\Unit;
+
+use Tighten\SolanaPhpSdk\Borsh\Borsh;
+use Tighten\SolanaPhpSdk\Tests\TestCase;
+
+class Test {
+    public $x;
+    public $y;
+    public $z;
+    public $q;
+
+    public function __construct() {}
+}
+
+class BorshTest extends TestCase
+{
+    /** @test */
+    public function it_serialize_object()
+    {
+        $value = new Test();
+        $value->x = 255;
+        $value->y = 20;
+        $value->z = '123';
+        $value->q = [1, 2, 3];
+
+        $schema = [
+            Test::class => [
+                'kind' => 'struct',
+                'fields' => [
+                    ['x', 'u8'],
+                    ['y', 'u64'],
+                    ['z', 'string'],
+                    ['q', [3]],
+                ],
+            ],
+        ];
+
+        $buffer = Borsh::serialize($schema, $value);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+
+        $this->assertInstanceOf(Test::class, $newValue);
+        $this->assertEquals(255, $newValue->x);
+        $this->assertEquals(20, $newValue->y);
+        $this->assertEquals('123', $newValue->z);
+        $this->assertEquals([1, 2, 3], $newValue->q);
+    }
+
+    /** @test */
+    public function it_serialize_nested()
+    {
+        $child = new Test();
+        $child->q = [1, 2, 4];
+
+        $parent = new Test();
+        $parent->x = 255;
+        $parent->y = $child;
+
+        $schema = [
+            Test::class => [
+                'kind' => 'struct',
+                'fields' => [
+                    ['x', 'u8'],
+                    ['y', Test::class],
+                    ['q', [3]],
+                ],
+            ],
+        ];
+
+        $buffer = Borsh::serialize($schema, $parent);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+
+        $this->assertInstanceOf(Test::class, $newValue);
+        $this->assertEquals(255, $newValue->x);
+        $this->assertEquals(20, $newValue->y);
+        $this->assertEquals('123', $newValue->z);
+        $this->assertEquals([1, 2, 3], $newValue->q);
+    }
+
+    /** @test */
+    public function it_serialize_optional_field()
+    {
+        $schema = [
+            Test::class => [
+                'kind' => 'struct',
+                'fields' => [
+                    ['x', [
+                        'kind' => 'option',
+                        'type' => 'string',
+                    ]],
+                ],
+            ],
+        ];
+
+        $value = new Test();
+        $value->x = 'bacon';
+        $buffer = Borsh::serialize($schema, $value);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+        $this->assertEquals('bacon', $newValue->x);
+
+        $value = new Test();
+        $value->x = null;
+        $buffer = Borsh::serialize($schema, $value);
+        $newValue = Borsh::deserialize($schema, Test::class, $buffer);
+        $this->assertNull($newValue->x);
+    }
+}

--- a/tests/Unit/BufferTest.php
+++ b/tests/Unit/BufferTest.php
@@ -9,10 +9,10 @@ use Tighten\SolanaPhpSdk\PublicKey;
 use Tighten\SolanaPhpSdk\Tests\TestCase;
 use Tighten\SolanaPhpSdk\Util\Buffer;
 
-class BufferableTest extends TestCase
+class BufferTest extends TestCase
 {
     /** @test */
-    public function it_bufferable()
+    public function it_buffer_push_fixed_length()
     {
         $lamports = 4;
         $space = 6;
@@ -29,8 +29,13 @@ class BufferableTest extends TestCase
             ...$programId->toBytes(),
         ];
 
+        $bufferable = Buffer::from()
+            ->push(SystemProgram::PROGRAM_INDEX_CREATE_ACCOUNT, 4)
+            ->push($lamports, 8)
+            ->push($space, 8)
+            ->push($programId)
+        ;
 
-//        $bufferable = Buffer::from()
-//            ->push()
+        $this->assertEquals($rawCreateAccountBinary, $bufferable->toArray());
     }
 }

--- a/tests/Unit/BufferTest.php
+++ b/tests/Unit/BufferTest.php
@@ -30,9 +30,15 @@ class BufferTest extends TestCase
         ];
 
         $bufferable = Buffer::from()
-            ->push(SystemProgram::PROGRAM_INDEX_CREATE_ACCOUNT, 4)
-            ->push($lamports, 8)
-            ->push($space, 8)
+            ->push(
+                Buffer::from(SystemProgram::PROGRAM_INDEX_CREATE_ACCOUNT,Buffer::TYPE_INT, false)
+            )
+            ->push(
+                Buffer::from($lamports,Buffer::TYPE_LONG, false)
+            )
+            ->push(
+                Buffer::from($space,Buffer::TYPE_LONG, false)
+            )
             ->push($programId)
         ;
 


### PR DESCRIPTION
Known limitation:
1. Large numbers unsupported (anything over a long (64 bits)).
2. Enums - Don't really exist yet in PHP.

Todo in the future:
1. Support more datatypes:
    a. Maps (Associative arrays)
    b. [Much more](https://github.com/near/borsh#specification)