### PR TITLE
Fix "Return value of Tighten\SolanaPhpSdk\Program::__call() must be of the type array or null, int returned"

### DIFF
--- a/src/Program.php
+++ b/src/Program.php
@@ -14,7 +14,7 @@ class Program
         $this->client = $client;
     }
 
-    public function __call($method, $params = []): ?array
+    public function __call($method, $params = [])
     {
         return $this->client->call($method, ...$params);
     }


### PR DESCRIPTION
If we try to use this code to get the current block value from node, we get error ``Return value of Tighten\SolanaPhpSdk\Program::__call() must be of the type array or null, int returned``.

```
$client = new Connection(new SolanaRpcClient('api.mainnet-beta.solana.com'));
var_dump($client->getBlockHeight());
```

This occurr because the magic method expects the result to be an array or null, but int and strings can be returned as well depending on the RPC method called.