### PR TITLE
Header support added to the call method of SolanaRpcClient

### DIFF
--- a/src/SolanaRpcClient.php
+++ b/src/SolanaRpcClient.php
@@ -51,14 +51,15 @@ class SolanaRpcClient
     /**
      * @param string $method
      * @param array $params
+     * @param array $headers
      * @return mixed
      * @throws GenericException
      * @throws InvalidIdResponseException
      * @throws MethodNotFoundException
      */
-    public function call(string $method, array $params = [])
+    public function call(string $method, array $params = [], array $headers = [])
     {
-        $response = (new HttpFactory())->acceptJson()->post(
+        $response = (new HttpFactory())->acceptJson()->withHeaders($headers)->post(
             $this->endpoint,
             $this->buildRpc($method, $params)
         )->throw();


### PR DESCRIPTION
Some RPC services (https://runnode.com/) require an API key to be sent as header information. Header support will make it possible to send an API key.

![image](https://user-images.githubusercontent.com/1541412/150605528-c4ea45f5-b68c-450a-8338-5c2f61d8cf26.png)

Usage example:

![image](https://user-images.githubusercontent.com/1541412/150605711-60d7dc05-9352-44d5-aa94-7cea90f443df.png)
